### PR TITLE
Hide checkov and tflint commands show

### DIFF
--- a/terraform/main.mk
+++ b/terraform/main.mk
@@ -9,7 +9,7 @@ TERRAFORM_STATE_KEY = $(ENV)/terraform.tfstate
 TERRAFORM_STATE_PROFILE = $(AWS_PROFILE)
 TERRAFORM_STATE_DYNAMODB_TABLE ?= tf-state-lock
 TERRAFORM_STATE_BUCKET_NAME ?= $(NAMESPACE)-tf-state
-CHECKOV ?= $(DOCKER) run -v $(ENV_DIR):/tf -i bridgecrew/checkov -d /tf
+CHECKOV ?= $(DOCKER) run -v $(ENV_DIR):/tf -i bridgecrew/checkov -d /tf -s
 TFLINT ?= $(DOCKER) run --rm -v $(ENV_DIR):/data -t wata727/tflint
 TERRAFORM ?= $(shell which terraform)
 #TERRAFORM ?= $(DOCKER) run -w /terraform -v $(PWD)/:/terraform -i hashicorp/terraform:0.12.21 init
@@ -45,12 +45,17 @@ terraform.apply: terraform.init ## Deploy infrastructure
 	$(TERRAFORM) output -json > output.json
 
 terraform.checkov: ## Test infrastructure with checkov
+	@ echo "Testing with Checkov:"
+	@ echo "--------------------"
 	@ cd $(ENV_DIR)
-	$(CHECKOV)
+	@ $(CHECKOV)
 
 terraform.tflint:  ## Test infrastructure with tflint
+	@ echo "Testing with TFLint:"
+	@ echo "--------------------"
 	@ cd $(ENV_DIR)
-	$(TFLINT)
+	@ $(TFLINT) && \
+	echo "Test passed (OK)"
 
 terraform.refresh: terraform.init ## Test infrastructure
 	@ cd $(ENV_DIR) && \


### PR DESCRIPTION
### ***List of changes:***

  Change code to make sure we can see only results of testing.

### ***How to use:***
 - ```make test``` - run Checkov and TFLint testing
-  ```make terraform.tflint``` - run TFLint testing only
-  ```make terraform.checkov``` - run Checkov testing only

 

###  ***Testing Done:***

 ```make test```:

<img width="1273" alt="make test" src="https://user-images.githubusercontent.com/24703846/86140162-3eb69e80-baf9-11ea-8c53-c9ce398899e4.png">

```make terraform.checkov```:

<img width="951" alt="make terraform checkov" src="https://user-images.githubusercontent.com/24703846/86140273-5d1c9a00-baf9-11ea-8b09-9f9b65795b40.png">

```make terraform.tflint```:
  - if any errors:
<img width="1271" alt="make terraform tflint" src="https://user-images.githubusercontent.com/24703846/86140373-758cb480-baf9-11ea-9e29-659ae4ebfe1d.png">
   
  - if no errors:
<img width="765" alt="make terraform tflin No errors" src="https://user-images.githubusercontent.com/24703846/86140725-d2886a80-baf9-11ea-8ee9-bdcd54bade45.png">

 



