### PR TITLE
Add destroy infrastructure without confirmation option

### DIFF
--- a/terraform/main.mk
+++ b/terraform/main.mk
@@ -66,6 +66,10 @@ terraform.destroy: terraform confirm ## Destroy infrastructure
 	@ cd $(ENV_DIR) && \
 	$(TERRAFORM) destroy
 
+terraform.destroy-quiet: ## Destroy infrastructure without confirmation
+	@ cd $(ENV_DIR) && \
+	$(TERRAFORM) destroy -auto-approve
+
 env.use: terraform jq
 	@ [ -e $(ENV_DIR) ] && \
 	( \


### PR DESCRIPTION
## ***Changes:***
Add Terraform destroy action for Github Actions compability.

## ***Usage:***
To run quiet destroy you can use: 
```
make terraform.destroy-quiet
```
It will run Terraform destroy without any confirmation.