### PR TITLE
Add Terraform plan output

### DIFF
--- a/main.mk
+++ b/main.mk
@@ -11,6 +11,7 @@ NPM_TOKEN ?= nil
 
 ICMK_TEMPLATE_TERRAFORM_BACKEND_CONFIG = $(INFRA_DIR)/icmk/terraform/templates/backend.tf.gotmpl
 ICMK_TEMPLATE_TERRAFORM_VARS = $(INFRA_DIR)/icmk/terraform/templates/terraform.tfvars.gotmpl
+ICMK_TEMPLATE_TERRAFORM_TFPLAN = $(INFRA_DIR)/icmk/terraform/templates/terraform.tfplan.gotmpl
 
 # We are using a tag from AWS User which would tell us which environment this user is using. You can always override it.
 ENV ?= $(AWS_DEV_ENV_NAME)
@@ -65,6 +66,7 @@ GOMPLATE ?= $(DOCKER) run \
 	-e TERRAFORM_STATE_REGION="$(TERRAFORM_STATE_REGION)" \
 	-e TERRAFORM_STATE_PROFILE="$(TERRAFORM_STATE_PROFILE)" \
 	-e TERRAFORM_STATE_DYNAMODB_TABLE="$(TERRAFORM_STATE_DYNAMODB_TABLE)" \
+	-v $(ENV_DIR):/temp \
 	--rm -i hairyhenderson/gomplate
 
 ECHO = @echo

--- a/terraform/main.mk
+++ b/terraform/main.mk
@@ -41,9 +41,8 @@ terraform.init: gomplate terraform
 # TODO: Potentionally replace gomplate by terragrunt
 # TODO:? Implement -target approach so we can deploy specific apps only
 # TODO: generate env vars into tfvars in only one task
-terraform.apply: terraform.init ## Deploy infrastructure
+terraform.apply: terraform.plan ## Deploy infrastructure
 	@ cd $(ENV_DIR) && \
-	$(TERRAFORM) plan -out=tfplan -input=false && \
 	$(TERRAFORM) apply -input=false tfplan && \
 	$(TERRAFORM) output -json > output.json	&& \
 	$(CMD_SAVE_OUTPUT_TO_SSM)
@@ -82,7 +81,7 @@ terraform.output-to-ssm: ## Manual upload output.json to AWS SSM. Output.json en
 	@ cd $(ENV_DIR) && \
 	$(CMD_SAVE_OUTPUT_TO_SSM)
 
-terraform.plan-output: terraform.init ## Terraform plan output for Github Action
+terraform.plan: terraform.init ## Terraform plan output for Github Action
 	@ cd $(ENV_DIR) && \
 	$(TERRAFORM) plan -out=tfplan -input=false && \
 	$(TERRAFORM) show tfplan -input=false -no-color > $(ENV_DIR)/tfplan.txt

--- a/terraform/main.mk
+++ b/terraform/main.mk
@@ -82,6 +82,12 @@ terraform.output-to-ssm: ## Manual upload output.json to AWS SSM. Output.json en
 	@ cd $(ENV_DIR) && \
 	$(CMD_SAVE_OUTPUT_TO_SSM)
 
+terraform.plan-output: terraform.init ## Terraform plan output for Github Action
+	@ cd $(ENV_DIR) && \
+	$(TERRAFORM) plan -out=tfplan -input=false && \
+	$(TERRAFORM) show tfplan -input=false -no-color > $(ENV_DIR)/tfplan.txt
+	cat $(ICMK_TEMPLATE_TERRAFORM_TFPLAN) | $(GOMPLATE) > $(ENV_DIR)/tfplan.md
+
 env.use: terraform jq
 	@ [ -e $(ENV_DIR) ] && \
 	( \

--- a/terraform/main.mk
+++ b/terraform/main.mk
@@ -84,7 +84,7 @@ terraform.output-to-ssm: ## Manual upload output.json to AWS SSM. Output.json en
 terraform.plan: terraform.init ## Terraform plan output for Github Action
 	@ cd $(ENV_DIR) && \
 	$(TERRAFORM) plan -out=tfplan -input=false && \
-	$(TERRAFORM) show tfplan -input=false -no-color > $(ENV_DIR)/tfplan.txt
+	$(TERRAFORM) show tfplan -input=false -no-color > $(ENV_DIR)/tfplan.txt && \
 	cat $(ICMK_TEMPLATE_TERRAFORM_TFPLAN) | $(GOMPLATE) > $(ENV_DIR)/tfplan.md
 
 env.use: terraform jq

--- a/terraform/templates/terraform.tfplan.gotmpl
+++ b/terraform/templates/terraform.tfplan.gotmpl
@@ -1,0 +1,5 @@
+# Terraform Changes
+```
+{{file.Read "/temp/tfplan.txt"}}
+```
+


### PR DESCRIPTION
### What's new:
 - Add `make terraform.plan` command for Github Actions

### Usage:
Mainly this task was created for usage with Github Actions, but you can run this command locally:
- Install ICMK to nutcorp-backend.
- You can run the command locally: `make terraform.plan`. 
The result you can see in the environment directory: `tfplan.txt` and `tfplan.md`
