### PR TITLE
Additional Terraform destroy to terrafom.destroy-quiet 

### DIFF
--- a/terraform/main.mk
+++ b/terraform/main.mk
@@ -77,7 +77,7 @@ terraform.destroy: terraform confirm ## Destroy infrastructure
 
 terraform.destroy-quiet: ## Destroy infrastructure without confirmation
 	@ cd $(ENV_DIR) && \
-	$(TERRAFORM) destroy -auto-approve
+	$(TERRAFORM) destroy -auto-approve -force || $(TERRAFORM) destroy -auto-approve -force
 
 terraform.output-to-ssm: ## Manual upload output.json to AWS SSM. Output.json encoded in base64.
 	@ cd $(ENV_DIR) && \


### PR DESCRIPTION
### What's new:
 - Add  additional `Terraform destroy command` to `terraform.destroy-quiet` ICMK task
This needs for complete removal of the AWS sources.
