### PR TITLE
Add serverless commands for "serverless-domain-manager" plugin

### DIFF
--- a/serverless/main.mk
+++ b/serverless/main.mk
@@ -19,9 +19,9 @@ CMD_SLS_SERVICE_INVOKE = $(SLS) invoke --function $(SVC) --path $(EVENT_FILE) --
 CMD_SLS_SERVICE_DESTROY = $(SLS) remove --config $(SLS_FILE) --service $(SVC) --verbose --region $(AWS_REGION) --env $(ENV) --profile $(AWS_PROFILE)
 CMD_SLS_SERVICE_BUILD = cd $(ROOT_DIR)/$(PROJECT_PATH) && make
 CMD_SLS_SERVICE_SECRETS = $(CMD_SERVICE_SECRETS_PUSH)
-#This works with "serverless-domain-manager" plugin and provide domain creation and remove
-CMD_SLS_SERVICE_DOMAIN_CREATE = $(SLS) create_domain
-CMD_SLS_SERVICE_DOMAIN_DELETE = $(SLS) delete_domain
+# This works with "serverless-domain-manager" plugin and provide domain creation and remove
+CMD_SLS_SERVICE_DOMAIN_CREATE = $(SLS) create_domain --verbose --region $(AWS_REGION) --env $(ENV) --profile $(AWS_PROFILE)
+CMD_SLS_SERVICE_DOMAIN_DELETE = $(SLS) delete_domain --verbose --region $(AWS_REGION) --env $(ENV) --profile $(AWS_PROFILE)
 
 # Tasks
 ########################################################################################################################

--- a/serverless/main.mk
+++ b/serverless/main.mk
@@ -20,8 +20,8 @@ CMD_SLS_SERVICE_DESTROY = $(SLS) remove --config $(SLS_FILE) --service $(SVC) --
 CMD_SLS_SERVICE_BUILD = cd $(ROOT_DIR)/$(PROJECT_PATH) && make
 CMD_SLS_SERVICE_SECRETS = $(CMD_SERVICE_SECRETS_PUSH)
 # This works with "serverless-domain-manager" plugin and provide domain creation and remove
-CMD_SLS_SERVICE_DOMAIN_CREATE = $(SLS) create_domain --verbose --region $(AWS_REGION) --env $(ENV) --profile $(AWS_PROFILE)
-CMD_SLS_SERVICE_DOMAIN_DELETE = $(SLS) delete_domain --verbose --region $(AWS_REGION) --env $(ENV) --profile $(AWS_PROFILE)
+CMD_SLS_SERVICE_CREATE_DOMAIN = $(SLS) create_domain --verbose --region $(AWS_REGION) --env $(ENV) --profile $(AWS_PROFILE)
+CMD_SLS_SERVICE_DELETE_DOMAIN = $(SLS) delete_domain --verbose --region $(AWS_REGION) --env $(ENV) --profile $(AWS_PROFILE)
 
 # Tasks
 ########################################################################################################################

--- a/serverless/main.mk
+++ b/serverless/main.mk
@@ -19,6 +19,9 @@ CMD_SLS_SERVICE_INVOKE = $(SLS) invoke --function $(SVC) --path $(EVENT_FILE) --
 CMD_SLS_SERVICE_DESTROY = $(SLS) remove --config $(SLS_FILE) --service $(SVC) --verbose --region $(AWS_REGION) --env $(ENV) --profile $(AWS_PROFILE)
 CMD_SLS_SERVICE_BUILD = cd $(ROOT_DIR)/$(PROJECT_PATH) && make
 CMD_SLS_SERVICE_SECRETS = $(CMD_SERVICE_SECRETS_PUSH)
+#This works with "serverless-domain-manager" plugin and provide domain creation and remove
+CMD_SLS_SERVICE_DOMAIN_CREATE = $(SLS) create_domain
+CMD_SLS_SERVICE_DOMAIN_DELETE = $(SLS) delete_domain
 
 # Tasks
 ########################################################################################################################


### PR DESCRIPTION
### What's new:
 - Added commands for creating and deleting domain with `serverless-domain-manager` plugin.

### Usage:
- You can call these commands ( `CMD_SLS_SERVICE_CREATE_DOMAIN` and `CMD_SLS_SERVICE_DELETE_DOMAIN`) by adding them with aliases in Makefile in the root folder of your backend.

### Testing done:
`create_domain`:

[![asciicast](https://asciinema.org/a/1n6ZulVVskKFSEtAdrW7riRZE.svg)](https://asciinema.org/a/1n6ZulVVskKFSEtAdrW7riRZE)

`delete_domain`:

[![asciicast](https://asciinema.org/a/BQrp26lAWT1J54GkpIhZ6Cn8w.svg)](https://asciinema.org/a/BQrp26lAWT1J54GkpIhZ6Cn8w)
