### PR TITLE
Support multiple tier or stack/tier workspaces

### DIFF
--- a/main.mk
+++ b/main.mk
@@ -27,10 +27,10 @@ ENV_DIR ?= $(INFRA_DIR)/env/$(ENV)
 ifneq (,$(TIER))
     ifneq (,$(STACK))
         ENV_DIR:=$(ENV_DIR)/$(STACK)/$(TIER)
-        TERRAFORM_STATE_KEY=$(ENV)/$(STACK)/$(TIER)
+        TERRAFORM_STATE_KEY=$(ENV)/$(STACK)/$(TIER)/terraform.tfstate
     else
         ENV_DIR:=$(ENV_DIR)/$(TIER)
-        TERRAFORM_STATE_KEY=$(ENV)/$(TIER)
+        TERRAFORM_STATE_KEY=$(ENV)/$(TIER)/terraform.tfstate
     endif
 endif
 PROJECT_PATH ?= projects/$(SVC)

--- a/main.mk
+++ b/main.mk
@@ -49,6 +49,8 @@ icmk.debug:
 	@echo "\033[36mPWD\033[0m: $(PWD)"
 	@echo "\033[36mICMK_VERSION\033[0m: $(ICMK_VERSION)"
 	@echo "\033[36mICMK_GIT_REVISION\033[0m: $(ICMK_GIT_REVISION)"
+	@echo "\033[36mENV_DIR\033[0m: $(ENV_DIR)"
+
 
 up: docker
 	# TODO: This should probably use individual apps "up" definitions

--- a/main.mk
+++ b/main.mk
@@ -24,6 +24,15 @@ ICMK_TEMPLATE_TERRAFORM_TFPLAN = $(INFRA_DIR)/icmk/terraform/templates/terraform
 # We are using a tag from AWS User which would tell us which environment this user is using. You can always override it.
 ENV ?= $(AWS_DEV_ENV_NAME)
 ENV_DIR ?= $(INFRA_DIR)/env/$(ENV)
+ifneq (,$(TIER))
+    ifneq (,$(STACK))
+        ENV_DIR:=$(ENV_DIR)/$(STACK)/$(TIER)
+        TERRAFORM_STATE_KEY=$(ENV)/$(STACK)/$(TIER)
+    else
+        ENV_DIR:=$(ENV_DIR)/$(TIER)
+        TERRAFORM_STATE_KEY=$(ENV)/$(TIER)
+    endif
+endif
 PROJECT_PATH ?= projects/$(SVC)
 SERVICE_NAME ?= $(ENV)-$(SVC)
 # Tasks

--- a/main.mk
+++ b/main.mk
@@ -24,14 +24,18 @@ ICMK_TEMPLATE_TERRAFORM_TFPLAN = $(INFRA_DIR)/icmk/terraform/templates/terraform
 # We are using a tag from AWS User which would tell us which environment this user is using. You can always override it.
 ENV ?= $(AWS_DEV_ENV_NAME)
 ENV_DIR ?= $(INFRA_DIR)/env/$(ENV)
+
+# Support for stack/tier workspace paths
 ifneq (,$(TIER))
-    ifneq (,$(STACK))
-        ENV_DIR:=$(ENV_DIR)/$(STACK)/$(TIER)
-        TERRAFORM_STATE_KEY=$(ENV)/$(STACK)/$(TIER)/terraform.tfstate
-    else
-        ENV_DIR:=$(ENV_DIR)/$(TIER)
-        TERRAFORM_STATE_KEY=$(ENV)/$(TIER)/terraform.tfstate
-    endif
+	ifneq (,$(STACK))
+		ENV_DIR:=$(ENV_DIR)/$(STACK)/$(TIER)
+		TERRAFORM_STATE_KEY=$(ENV)/$(STACK)/$(TIER)/terraform.tfstate
+		-include $(INFRA_DIR)/env/$(ENV)/$(STACK)/$(TIER)/*.mk
+	else
+		ENV_DIR:=$(ENV_DIR)/$(TIER)
+		TERRAFORM_STATE_KEY=$(ENV)/$(TIER)/terraform.tfstate
+		-include $(INFRA_DIR)/env/$(ENV)/$(TIER)/*.mk
+	endif
 endif
 PROJECT_PATH ?= projects/$(SVC)
 SERVICE_NAME ?= $(ENV)-$(SVC)

--- a/terraform/main.mk
+++ b/terraform/main.mk
@@ -4,9 +4,8 @@ SSH_PUBLIC_KEY ?= $(shell cat ~/.ssh/id_rsa.pub)
 SSH_PUBLIC_KEY_BASE64 = $(shell echo "$(SSH_PUBLIC_KEY)" | $(BASE64))
 EC2_KEY_PAIR_NAME ?= $(ENV)-$(NAMESPACE)
 ENV_DIR ?= $(INFRA_DIR)/env/$(ENV)
-OUTPUT_JSON_FILE = $(INFRA_DIR)/env/$(ENV)/output.json
+OUTPUT_JSON_FILE = $(ENV_DIR)/output.json
 TERRAFORM_VERSION ?= "0.12.29"
-
 
 
 # Terraform Backend Config
@@ -18,7 +17,6 @@ CHECKOV ?= $(DOCKER) run -v $(ENV_DIR):/tf -i bridgecrew/checkov -d /tf -s
 TFLINT ?= $(DOCKER) run --rm -v $(ENV_DIR):/data -t wata727/tflint
 TFLOCK ?= $(DOCKER) run --rm --hostname=$(USER)-icmk-terraform -v $(ENV_DIR):/$(ENV_DIR) -v "$(ENV_DIR)/.terraform":/"$(ENV_DIR)/.terraform" -v "$(INFRA_DIR)":"$(INFRA_DIR)" -v $(HOME)/.aws/:/root/.aws:ro -w $(ENV_DIR) -e AWS_PROFILE=$(AWS_PROFILE) -e ENV=$(ENV) hazelops/tflock
 TERRAFORM ?= $(DOCKER) run --rm --hostname=$(USER)-icmk-terraform -v $(ENV_DIR):/$(ENV_DIR) -v "$(ENV_DIR)/.terraform":/"$(ENV_DIR)/.terraform" -v "$(INFRA_DIR)":"$(INFRA_DIR)" -v $(HOME)/.aws/:/root/.aws:ro -w $(ENV_DIR) -e AWS_PROFILE=$(AWS_PROFILE) -e ENV=$(ENV) hashicorp/terraform:$(TERRAFORM_VERSION)
-
 
 CMD_SAVE_OUTPUT_TO_SSM = $(AWS) --profile "$(AWS_PROFILE)" ssm put-parameter --name "/$(ENV)/terraform-output" --type "SecureString" --tier "Intelligent-Tiering" --data-type "text" --overwrite --value "$$(cat $(OUTPUT_JSON_FILE) | $(BASE64))" > /dev/null && echo "\033[32m[OK]\033[0m Terraform output saved to ssm://$(ENV)/terraform-output" || (echo "\033[31m[ERROR]\033[0m Terraform output saving failed" && exit 1)
 # Optional cmd to be used, because the branch related to TF v0.13 upgrade already have updated versions.tf files


### PR DESCRIPTION
This allows a deployment to consist of multiple "default workspaces" or paths.

The user sets either TIER or TIER & STACK to their values matching the file tree.

Testing done:

1. Observed behavior of Terraform plan with either var set.

2. Additions to make env.debug.

Tested with make env.debug

With $STACK and $TIER set:
`.infra/env/dev/redacted/db`

With $TIER set:
`.infra/env/dev/db`

With $TIER unset:
`.infra/env/dev`

WITH $TIER set and $STACK unset:
`.infra/env/dev`

