### PR TITLE
Resolve symlinks in PROJECT_PATH

### DIFF
--- a/main.mk
+++ b/main.mk
@@ -37,7 +37,8 @@ ifneq (,$(TIER))
 		-include $(INFRA_DIR)/env/$(ENV)/$(TIER)/*.mk
 	endif
 endif
-PROJECT_PATH ?= $(shell cd projects/$(SVC) && pwd -P)
+PROJECT_PATH_ABS=$(shell cd projects/$(SVC) && pwd -P)
+PROJECT_PATH = projects/$(shell basename $(PROJECT_PATH_ABS))
 SERVICE_NAME ?= $(ENV)-$(SVC)
 # Tasks
 ########################################################################################################################

--- a/main.mk
+++ b/main.mk
@@ -37,7 +37,7 @@ ifneq (,$(TIER))
 		-include $(INFRA_DIR)/env/$(ENV)/$(TIER)/*.mk
 	endif
 endif
-PROJECT_PATH ?= projects/$(SVC)
+PROJECT_PATH ?= $(shell cd projects/$(SVC) && pwd -P)
 SERVICE_NAME ?= $(ENV)-$(SVC)
 # Tasks
 ########################################################################################################################


### PR DESCRIPTION
Resolve issues with Docker lstat calls on symlinks

Makefile
```
CUT=cut
SVC = $(shell echo $(@) | $(CUT) -d. -f1 )
PROJECT_PATH ?= $(shell cd projects/$(SVC) && pwd -P)

foo:
	@echo $(SVC)
	@echo $(PROJECT_PATH)
```
```
$ make foo
foo
/home/redacted/redacted/maketest/projects/bar
$ ls -al projects/foo
lrwxrwxrwx 1 redacted redacted 3 Jan 23 14:03 projects/foo -> bar
```

