### PR TITLE
Feature/define versions in vars

### DIFF
--- a/aws/main.mk
+++ b/aws/main.mk
@@ -20,7 +20,7 @@ AWS ?= $(DOCKER) run \
 	-i \
 	-e AWS_PROFILE="$(AWS_PROFILE)" \
 	-e AWS_REGION="$(AWS_REGION)" \
-	amazon/aws-cli:2.0.40 $(AWS_ARGS)
+	amazon/aws-cli:$(AWS_CLI_VERSION) $(AWS_ARGS)
 
 CMD_AWS_LOGS_TAIL = @$(AWS) logs tail $(SERVICE_NAME) --follow
 CMD_AWS_EC2_IMPORT_KEY_PAIR = @$(AWS) ec2 import-key-pair  --key-name="$(EC2_KEY_PAIR_NAME)" --public-key-material="$(SSH_PUBLIC_KEY_BASE64)"

--- a/aws/variables.mk
+++ b/aws/variables.mk
@@ -1,0 +1,3 @@
+# This file should contain variables used in current module
+##################################################################
+AWS_CLI_VERSION ?= 2.0.40

--- a/aws/variables.mk
+++ b/aws/variables.mk
@@ -1,3 +1,4 @@
 # This file should contain variables used in current module
 ##################################################################
+# main variables
 AWS_CLI_VERSION ?= 2.0.40


### PR DESCRIPTION
## Description
Attempt to carry out variables to a separate file `variables.mk` in module folder.
This file should contain only variables, which have determined default values with `string` type.

This can help `ICMK` developers:
- to read code better
- to start thinking on module structure and unit testing

## Testing done

> .infra$ make env.debug
=== ICMK Info ===
ENV: andrei-dev
TAG: andrei-dev
INFRA_DIR: /mnt/c/Users/gloov/hazelops/git/nutcorp-backend/.infra
PWD: /mnt/c/Users/gloov/hazelops/git/nutcorp-backend
ICMK_VERSION: master
ICMK_GIT_REVISION: 36ce3e20bae937c07729133cef2d5d91fbc87033 2.0.0-100-g36ce3e2
ENV_DIR: /mnt/c/Users/gloov/hazelops/git/nutcorp-backend/.infra/env/andrei-dev
=== System Info ===
OS_NAME: Linux
LINUX_ARCH: x86_64
ARCH: 64bit
=== AWS Environment Info ===
AWS_DEV_ENV_NAME: andrei-dev (User env is not configured)
AWS_ACCOUNT: XXXXXXXXXXXX
AWS_PROFILE: hazelops
AWS_USER: XXXXXX
