### PR TITLE
Remove latest tag from image

### DIFF
--- a/aws/ecs.mk
+++ b/aws/ecs.mk
@@ -35,13 +35,12 @@ CMD_ECS_SERVICE_DOCKER_BUILD = DOCKER_BUILDKIT=$(ENABLE_BUILDKIT) $(DOCKER) buil
 	--build-arg PROJECT_PATH=$(PROJECT_PATH) \
 	$(DOCKER_BUILD_ADDITIONAL_PARAMS)
 
-
 CMD_ECS_SERVICE_DOCKER_PUSH = \
 	$(DOCKER) push $(DOCKER_REGISTRY)/$(DOCKER_IMAGE_NAME):$(TAG) && \
 	$(DOCKER) push $(DOCKER_REGISTRY)/$(DOCKER_IMAGE_NAME):$(TAG_LATEST)
 
-CMD_ECR_DOCKER_CLEAR_CACHE = $(shell $(AWS) ecr batch-delete-image --repository-name $(DOCKER_IMAGE_NAME) --image-ids imageTag=$(TAG_LATEST) | $(JQ) -r '.failures[].failureReason')
-CMD_ECR_DOCKER_CLEAR_CACHE_OUTPUT = $$(if [ -z "$(shell echo $(CMD_ECR_DOCKER_CLEAR_CACHE) )" ];then echo "\n\033[32m[OK]\033[0m '$(TAG_LATEST)' tag was removed from AWS ECR"; else echo "\n\033[33m[WARNING]\033[0m $(CMD_ECR_DOCKER_CLEAR_CACHE)"; fi)
+CMD_ECR_DOCKER_CLEAR_CACHE_TASK = $(shell $(AWS) ecr batch-delete-image --repository-name $(DOCKER_IMAGE_NAME) --image-ids imageTag=$(TAG_LATEST) | $(JQ) -r '.failures[].failureReason')
+CMD_ECR_DOCKER_CLEAR_CACHE = @echo $$(if [ -z "$(shell echo $(CMD_ECR_DOCKER_CLEAR_CACHE_TASK) )" ];then echo "\n\033[32m[OK]\033[0m '$(TAG_LATEST)' tag was removed from AWS ECR"; else echo "\n\033[33m[WARNING]\033[0m $(CMD_ECR_DOCKER_CLEAR_CACHE_TASK)"; fi)
 
 # TODO: Add log polling instead of sleep?
 CMD_ECS_SERVICE_TASK_RUN = @echo "Task for definition $(ECS_SERVICE_TASK_DEFINITION_ARN) has been started.\nLogs: https://console.aws.amazon.com/ecs/home?region=$(AWS_REGION)$(HASHSIGN)/clusters/$(ECS_CLUSTER_NAME)/tasks/$(ECS_SERVICE_TASK_ID)/details"

--- a/aws/ecs.mk
+++ b/aws/ecs.mk
@@ -39,7 +39,7 @@ CMD_ECS_SERVICE_DOCKER_PUSH = \
 	$(DOCKER) push $(DOCKER_REGISTRY)/$(DOCKER_IMAGE_NAME):$(TAG) && \
 	$(DOCKER) push $(DOCKER_REGISTRY)/$(DOCKER_IMAGE_NAME):$(TAG_LATEST)
 
-CMD_ECR_DOCKER_CLEAR_CACHE = @echo "Removing '$(TAG_LATEST)' tag from AWS ECR" && $(AWS) ecr batch-delete-image --repository-name $(DOCKER_IMAGE_NAME) --image-ids imageTag=$(TAG_LATEST) | $(JQ) -je 'select(.failures[].failureReason != null) | def yellow: "\u001b[33m"; def reset: "\u001b[0m"; yellow + "[WARNING]:", reset + "\( .failures[].failureReason)"' || echo "\033[32m[OK]\033[0m '$(TAG_LATEST)' tag was removed from AWS ECR"
+CMD_ECR_DOCKER_PURGE_CACHE = @echo "Removing '$(TAG_LATEST)' tag from AWS ECR" && $(AWS) ecr batch-delete-image --repository-name $(DOCKER_IMAGE_NAME) --image-ids imageTag=$(TAG_LATEST) | $(JQ) -er 'select(.failures[].failureReason != null) | def yellow: "\u001b[33m"; def reset: "\u001b[0m"; yellow + "[WARNING]:", reset + "\( .failures[].failureReason)"' || echo "\033[32m[OK]\033[0m '$(TAG_LATEST)' tag was removed from AWS ECR"
 
 # TODO: Add log polling instead of sleep?
 CMD_ECS_SERVICE_TASK_RUN = @echo "Task for definition $(ECS_SERVICE_TASK_DEFINITION_ARN) has been started.\nLogs: https://console.aws.amazon.com/ecs/home?region=$(AWS_REGION)$(HASHSIGN)/clusters/$(ECS_CLUSTER_NAME)/tasks/$(ECS_SERVICE_TASK_ID)/details"

--- a/aws/ecs.mk
+++ b/aws/ecs.mk
@@ -39,8 +39,7 @@ CMD_ECS_SERVICE_DOCKER_PUSH = \
 	$(DOCKER) push $(DOCKER_REGISTRY)/$(DOCKER_IMAGE_NAME):$(TAG) && \
 	$(DOCKER) push $(DOCKER_REGISTRY)/$(DOCKER_IMAGE_NAME):$(TAG_LATEST)
 
-CMD_ECR_BATCH_DELETE_IMAGE = $(shell $(AWS) ecr batch-delete-image --repository-name $(DOCKER_IMAGE_NAME) --image-ids imageTag=$(TAG_LATEST) | $(JQ) -r '.failures[].failureReason')
-CMD_ECR_DOCKER_CLEAR_CACHE = @echo $$(if [ -z "$(shell echo $(CMD_ECR_BATCH_DELETE_IMAGE))" ];then echo "\n\033[32m[OK]\033[0m '$(TAG_LATEST)' tag was removed from AWS ECR"; else echo "\n\033[33m[WARNING]\033[0m $(CMD_ECR_BATCH_DELETE_IMAGE)"; fi)
+CMD_ECR_DOCKER_CLEAR_CACHE = @echo "Removing '$(TAG_LATEST)' tag from AWS ECR" && $(AWS) ecr batch-delete-image --repository-name $(DOCKER_IMAGE_NAME) --image-ids imageTag=$(TAG_LATEST) | $(JQ) -je 'select(.failures[].failureReason != null) | def yellow: "\u001b[33m"; def reset: "\u001b[0m"; yellow + "[WARNING]:", reset + "\( .failures[].failureReason)"' || echo "\033[32m[OK]\033[0m '$(TAG_LATEST)' tag was removed from AWS ECR"
 
 # TODO: Add log polling instead of sleep?
 CMD_ECS_SERVICE_TASK_RUN = @echo "Task for definition $(ECS_SERVICE_TASK_DEFINITION_ARN) has been started.\nLogs: https://console.aws.amazon.com/ecs/home?region=$(AWS_REGION)$(HASHSIGN)/clusters/$(ECS_CLUSTER_NAME)/tasks/$(ECS_SERVICE_TASK_ID)/details"

--- a/aws/ecs.mk
+++ b/aws/ecs.mk
@@ -39,8 +39,8 @@ CMD_ECS_SERVICE_DOCKER_PUSH = \
 	$(DOCKER) push $(DOCKER_REGISTRY)/$(DOCKER_IMAGE_NAME):$(TAG) && \
 	$(DOCKER) push $(DOCKER_REGISTRY)/$(DOCKER_IMAGE_NAME):$(TAG_LATEST)
 
-CMD_ECR_DOCKER_CLEAR_CACHE_TASK = $(shell $(AWS) ecr batch-delete-image --repository-name $(DOCKER_IMAGE_NAME) --image-ids imageTag=$(TAG_LATEST) | $(JQ) -r '.failures[].failureReason')
-CMD_ECR_DOCKER_CLEAR_CACHE = @echo $$(if [ -z "$(shell echo $(CMD_ECR_DOCKER_CLEAR_CACHE_TASK) )" ];then echo "\n\033[32m[OK]\033[0m '$(TAG_LATEST)' tag was removed from AWS ECR"; else echo "\n\033[33m[WARNING]\033[0m $(CMD_ECR_DOCKER_CLEAR_CACHE_TASK)"; fi)
+CMD_ECR_BATCH_DELETE_IMAGE = $(shell $(AWS) ecr batch-delete-image --repository-name $(DOCKER_IMAGE_NAME) --image-ids imageTag=$(TAG_LATEST) | $(JQ) -r '.failures[].failureReason')
+CMD_ECR_DOCKER_CLEAR_CACHE = @echo $$(if [ -z "$(shell echo $(CMD_ECR_BATCH_DELETE_IMAGE))" ];then echo "\n\033[32m[OK]\033[0m '$(TAG_LATEST)' tag was removed from AWS ECR"; else echo "\n\033[33m[WARNING]\033[0m $(CMD_ECR_BATCH_DELETE_IMAGE)"; fi)
 
 # TODO: Add log polling instead of sleep?
 CMD_ECS_SERVICE_TASK_RUN = @echo "Task for definition $(ECS_SERVICE_TASK_DEFINITION_ARN) has been started.\nLogs: https://console.aws.amazon.com/ecs/home?region=$(AWS_REGION)$(HASHSIGN)/clusters/$(ECS_CLUSTER_NAME)/tasks/$(ECS_SERVICE_TASK_ID)/details"

--- a/aws/ecs.mk
+++ b/aws/ecs.mk
@@ -40,7 +40,8 @@ CMD_ECS_SERVICE_DOCKER_PUSH = \
 	$(DOCKER) push $(DOCKER_REGISTRY)/$(DOCKER_IMAGE_NAME):$(TAG) && \
 	$(DOCKER) push $(DOCKER_REGISTRY)/$(DOCKER_IMAGE_NAME):$(TAG_LATEST)
 
-CMD_ECR_DOCKER_CLEAR_CACHE = @echo "Removing '$(TAG_LATEST)' tag from AWS ECR" && $(AWS) ecr batch-delete-image --repository-name $(DOCKER_IMAGE_NAME) --image-ids imageTag=$(TAG_LATEST) | $(JQ) -r '.failures[].failureReason' && echo "OK"
+CMD_ECR_DOCKER_CLEAR_CACHE = $(shell $(AWS) ecr batch-delete-image --repository-name $(DOCKER_IMAGE_NAME) --image-ids imageTag=$(TAG_LATEST) | $(JQ) -r '.failures[].failureReason')
+CMD_ECR_DOCKER_CLEAR_CACHE_OUTPUT = $$(if [ -z "$(shell echo $(CMD_ECR_DOCKER_CLEAR_CACHE) )" ];then echo "\n\033[32m[OK]\033[0m '$(TAG_LATEST)' tag was removed from AWS ECR"; else echo "\n\033[33m[WARNING]\033[0m $(CMD_ECR_DOCKER_CLEAR_CACHE)"; fi)
 
 # TODO: Add log polling instead of sleep?
 CMD_ECS_SERVICE_TASK_RUN = @echo "Task for definition $(ECS_SERVICE_TASK_DEFINITION_ARN) has been started.\nLogs: https://console.aws.amazon.com/ecs/home?region=$(AWS_REGION)$(HASHSIGN)/clusters/$(ECS_CLUSTER_NAME)/tasks/$(ECS_SERVICE_TASK_ID)/details"

--- a/aws/ecs.mk
+++ b/aws/ecs.mk
@@ -40,6 +40,8 @@ CMD_ECS_SERVICE_DOCKER_PUSH = \
 	$(DOCKER) push $(DOCKER_REGISTRY)/$(DOCKER_IMAGE_NAME):$(TAG) && \
 	$(DOCKER) push $(DOCKER_REGISTRY)/$(DOCKER_IMAGE_NAME):$(TAG_LATEST)
 
+CMD_ECR_DOCKER_CLEAR_CACHE = @echo "Removing '$(TAG_LATEST)' tag from AWS ECR" && $(AWS) ecr batch-delete-image --repository-name $(DOCKER_IMAGE_NAME) --image-ids imageTag=$(TAG_LATEST) | $(JQ) -r '.failures[].failureReason' && echo "OK"
+
 # TODO: Add log polling instead of sleep?
 CMD_ECS_SERVICE_TASK_RUN = @echo "Task for definition $(ECS_SERVICE_TASK_DEFINITION_ARN) has been started.\nLogs: https://console.aws.amazon.com/ecs/home?region=$(AWS_REGION)$(HASHSIGN)/clusters/$(ECS_CLUSTER_NAME)/tasks/$(ECS_SERVICE_TASK_ID)/details"
 CMD_ECS_SERVICE_SCALE = @$(ECS) scale --profile $(AWS_PROFILE) $(ECS_CLUSTER_NAME) $(ECS_TASK_NAME) $(SCALE)

--- a/examples/simple/Makefile
+++ b/examples/simple/Makefile
@@ -31,4 +31,4 @@ app.up:
 app.down:
 	$(CMD_SERVICE_LOCAL_DOWN)
 app.purge-cache:
-	$(CMD_ECR_DOCKER_CLEAR_CACHE)
+	$(CMD_ECR_DOCKER_PURGE_CACHE)

--- a/examples/simple/Makefile
+++ b/examples/simple/Makefile
@@ -30,3 +30,5 @@ app.up:
 	$(CMD_SERVICE_LOCAL_UP)
 app.down:
 	$(CMD_SERVICE_LOCAL_DOWN)
+app.purge-cache:
+	$(CMD_ECR_DOCKER_CLEAR_CACHE)


### PR DESCRIPTION
#### What's new:

 - Add remove of `$(TAG_LATEST)`  


#### How to use:

 - To remove `TAG_LATEST` you need to call in `Makefile` for example, `CMD_ECR_DOCKER_PURGE_CACHE` command
```
  app.purge-cache:
	$(CMD_ECR_DOCKER_PURGE_CACHE)
```

#### Testing done:

Remove `TAG_LATEST` when its exist:

[![asciicast](https://asciinema.org/a/mg2MwhJt6ZUiCR1OuU7jTkZr3.svg)](https://asciinema.org/a/mg2MwhJt6ZUiCR1OuU7jTkZr3)

When `TAG_LATEST` doesn't exists:

[![asciicast](https://asciinema.org/a/MqkSJVglRtJFxEGjcLBfR47NU.svg)](https://asciinema.org/a/MqkSJVglRtJFxEGjcLBfR47NU)