### PR TITLE
rds failover mechanism was added

### DIFF
--- a/aws/ecs.mk
+++ b/aws/ecs.mk
@@ -21,6 +21,7 @@ ECS_SERVICE_TASK_ID = $(eval ECS_SERVICE_TASK_ID := $(shell $(AWS) ecs run-task 
 ECS_SERVICE_TASK_DEFINITION_ARN = $(shell $(AWS) ecs describe-task-definition --task-definition $(ECS_TASK_NAME) | $(JQ) -r '.taskDefinition.taskDefinitionArn')
 
 CMD_ECS_SERVICE_DEPLOY = @$(ECS) deploy --profile $(AWS_PROFILE) $(ECS_CLUSTER_NAME) $(ECS_SERVICE_NAME) --task $(ECS_SERVICE_TASK_DEFINITION_ARN) --image $(SVC) $(DOCKER_REGISTRY)/$(DOCKER_IMAGE_NAME):$(TAG) --diff --rollback -e $(SVC) DD_VERSION $(TAG)
+CMD_ECS_SERVICE_REDEPLOY = @$(ECS) deploy --profile $(AWS_PROFILE) --region $(AWS_REGION)  $(ECS_CLUSTER_NAME) $(ECS_SERVICE_NAME) --diff --rollback
 CMD_ECS_SERVICE_DOCKER_BUILD = DOCKER_BUILDKIT=$(ENABLE_BUILDKIT) $(DOCKER) build \
 	. \
 	-t $(DOCKER_IMAGE_NAME) \
@@ -84,6 +85,7 @@ endif
 # Backwards Compatibility, should be removed in 2.0
 ########################################################################################################################
 CMD_SERVICE_DEPLOY = $(CMD_ECS_SERVICE_DEPLOY)
+CMD_SERVICE_REDEPLOY = $(CMD_ECS_SERVICE_REDEPLOY)
 CMD_SERVICE_DOCKER_BUILD = $(CMD_ECS_SERVICE_DOCKER_BUILD)
 CMD_SERVICE_DOCKER_PUSH = $(CMD_ECS_SERVICE_DOCKER_PUSH)
 CMD_SERVICE_TASK_RUN = $(CMD_ECS_SERVICE_TASK_RUN)

--- a/aws/rds.mk
+++ b/aws/rds.mk
@@ -1,0 +1,18 @@
+# This file contains AWS RDS related logic
+##################################################################
+# Macroses
+########################################################################################################################
+# Default value for RDS CLUSTER Identifier
+RDS_DB_CLUSTER_IDENTIFIER ?= $(ENV)-$(RDS_DB_SUFFIX)
+
+# It gets a current DB Writer instance Identifier
+CMD_RDS_DB_CLUSTER_WR_INSTANCE_IDENTIFIER = $$($(AWS) rds describe-db-clusters --db-cluster-identifier $(RDS_DB_CLUSTER_IDENTIFIER) | $(JQ) -r --arg DB_ID $(RDS_DB_CLUSTER_IDENTIFIER) '.DBClusters[] | select(contains({DBClusterIdentifier: $$DB_ID})) | .DBClusterMembers[] | select(contains({IsClusterWriter: true})) | .DBInstanceIdentifier')
+
+# It enables Failover mechanism and stories instance identifier
+CMD_RDS_DB_CLUSTER_WR_INSTANCE_IDENTIFIER_PREVIOUS = $(eval CMD_RDS_DB_CLUSTER_WR_INSTANCE_IDENTIFIER_PREVIOUS := $(shell $(AWS) rds failover-db-cluster --db-cluster-identifier $(RDS_DB_CLUSTER_IDENTIFIER) | $(JQ) -r '.DBCluster.DBClusterMembers[] | select(contains({IsClusterWriter: true})) | .DBInstanceIdentifier'))$(CMD_RDS_DB_CLUSTER_WR_INSTANCE_IDENTIFIER_PREVIOUS)
+
+# Simple loop for looking for Writer instance switching
+CMD_RDS_DB_CLUSTER_FAILOVER = WAIT_TIME=0; SUCCESS_FLAG=0; printf "%s" "Getting new Primary DB instance."; while [ $$WAIT_TIME -lt $$(($(RDS_FAILOVER_TIMEOUT) * 60)) ]; do if [ $(CMD_RDS_DB_CLUSTER_WR_INSTANCE_IDENTIFIER_PREVIOUS) != $(CMD_RDS_DB_CLUSTER_WR_INSTANCE_IDENTIFIER) ]; then echo "\n\n\033[32m[OK]\033[0m The Primary DB instance has been changed to '$(CMD_RDS_DB_CLUSTER_WR_INSTANCE_IDENTIFIER)'.\n"; SUCCESS_FLAG=1; break; else printf "%s" "."; WAIT_TIME=$$(expr $$WAIT_TIME + $(RDS_FAILOVER_LOOP_TIMEOUT)); sleep $(RDS_FAILOVER_LOOP_TIMEOUT); fi; done; if [ $$SUCCESS_FLAG -ne 1 ]; then echo "\n\033[31m[ERROR]\033[0m Something went wrong during RDS Failover process."; exit 1; fi
+
+# Notification before main logic invocation
+CMD_RDS_DB_CLUSTER_FAILOVER_RUN = @ echo "\nFailover process within '$(RDS_DB_CLUSTER_IDENTIFIER)' RDS cluster has been started. \nThe Primary DB instance was '$(CMD_RDS_DB_CLUSTER_WR_INSTANCE_IDENTIFIER_PREVIOUS)'.\n" && $(CMD_RDS_DB_CLUSTER_FAILOVER)

--- a/aws/variables.mk
+++ b/aws/variables.mk
@@ -20,3 +20,10 @@ LOCALSTACK_VERSION ?= latest
 LOCALSTACK_WEB_UI_PORT ?= 8088
 LOCALSTACK_PORTS ?= "4510-4620"
 LOCALSTACK_SERVICE_LIST ?= "dynamodb,s3,lambda,cloudformation,sts,iam,acm,ec2,route53,ssm,cloudwatch,apigateway,ecs,ecr,events,serverless" #etc. serverless? api-gateway?
+
+# Maximum time for RDS Failover execution, in minutes
+RDS_FAILOVER_TIMEOUT ?= 5
+# Timeout of RDS Failover check, in seconds
+RDS_FAILOVER_LOOP_TIMEOUT ?= 3
+# Default suffix for RDS DB Identifier
+RDS_DB_SUFFIX ?= APP-DB


### PR DESCRIPTION
## Description
There were added:
1. RDS Failover mechanism enabling: switch Primary DB instance in AWS RDS Failover
2. AWS ECS service redeploying with previous task definition

## Tests
<a href="https://asciinema.org/a/U39wY1A9Ku4bLRPRMVmp0oHKk"><img src="https://asciinema.org/a/U39wY1A9Ku4bLRPRMVmp0oHKk" width="836"/></a>