### PR TITLE
Aws cli, Serverless

### DIFF
--- a/aws/main.mk
+++ b/aws/main.mk
@@ -15,7 +15,7 @@ AWS_ACCOUNT ?= $(shell [ -f ~/.aws/credentials ] && $(AWS) sts get-caller-identi
 AWS_DEV_ENV_NAME ?= $(shell [ -f ~/.aws/credentials ] && $(AWS) iam list-user-tags --user-name $(AWS_USER) | ( $(JQ) -e -r '.Tags[] | select(.Key == "devEnvironmentName").Value') || echo "$(ENV) (User env is not configured)")
 
 # $(AWS_ARGS) definition see in .infra/icmk/aws/localstack.mk
-AWS_ARM ?= $(DOCKER) run --user "$(CURRENT_USER_ID):$(CURRENT_USERGROUP_ID)" --platform "linux/amd64" \
+AWS_ARM ?= $(DOCKER) run --rm --user "$(CURRENT_USER_ID):$(CURRENT_USERGROUP_ID)" --platform "linux/amd64" \
 	-v $(HOME)/.aws/:/.aws \
 	-i \
 	-e AWS_PROFILE="$(AWS_PROFILE)" \
@@ -24,7 +24,7 @@ AWS_ARM ?= $(DOCKER) run --user "$(CURRENT_USER_ID):$(CURRENT_USERGROUP_ID)" --p
 	-e AWS_SHARED_CREDENTIALS_FILE="/.aws/credentials" \
 	amazon/aws-cli:$(AWS_CLI_VERSION) $(AWS_ARGS)
 
-AWS_DEFAULT ?= $(DOCKER) run --user "$(CURRENT_USER_ID):$(CURRENT_USERGROUP_ID)" \
+AWS_DEFAULT ?= $(DOCKER) run --rm --user "$(CURRENT_USER_ID):$(CURRENT_USERGROUP_ID)" \
 	-v $(HOME)/.aws/:/.aws \
 	-i \
 	-e AWS_PROFILE="$(AWS_PROFILE)" \

--- a/serverless/main.mk
+++ b/serverless/main.mk
@@ -1,14 +1,36 @@
 # Docker executors
 ########################################################################################################################
-SLS ?= $(DOCKER) run --rm --workdir=/opt/app -e AWS_PROFILE=$(AWS_PROFILE) -e LOCALSTACK_HOST=$(LOCALSTACK_HOST) -v $(ROOT_DIR)/$(PROJECT_PATH):/opt/app -v ~/.aws/:/root/.aws:ro $(SLS_DOCKER_IMAGE):$(SLS_VERSION) serverless
-NPM ?= $(DOCKER) run --user "$(CURRENT_USER_ID):$(CURRENT_USERGROUP_ID)" --rm --workdir=$(ROOT_DIR)/$(PROJECT_PATH) -v $(ROOT_DIR):$(ROOT_DIR) node:$(NODE_VERSION) npm
+SLS = @$(DOCKER) run --rm \
+	--user root:root \
+	--workdir=/app \
+	--entrypoint="/usr/local/bin/npx" \
+	-e AWS_PROFILE=$(AWS_PROFILE) \
+	-e LOCALSTACK_HOST=$(LOCALSTACK_HOST) \
+	-e SLS_DEBUG='$(SLS_DEBUG)' \
+	-e SLS_DEPRECATION_DISABLE='$(SLS_DEPRECATION_DISABLE)' \
+	-e SLS_WARNING_DISABLE='$(SLS_WARNING_DISABLE)' \
+	-v ~/.aws/:/root/.aws:ro \
+	-v $(ROOT_DIR)/$(PROJECT_PATH):/app \
+	-v $(ROOT_DIR)/$(PROJECT_PATH)/.serverless/:/root/.serverless \
+	-v $(ROOT_DIR)/.npm/:/root/.npm \
+	-v $(SVC)-node-modules:/app/node_modules \
+	node:$(NODE_VERSION) serverless \
+
+NPM ?= @$(DOCKER) run --rm \
+	--user root:root \
+	--workdir=/app \
+	-v $(ROOT_DIR)/$(PROJECT_PATH):/app \
+	-v $(ROOT_DIR)/$(PROJECT_PATH)/.config/:/root/.config \
+	-v $(ROOT_DIR)/.npm/:/root/.npm \
+	-v $(SVC)-node-modules:/app/node_modules \
+	node:$(NODE_VERSION) npm
 
 # Serverless CLI Reference
 ########################################################################################################################
 CMD_SLS_SERVICE_INSTALL = $(NPM) install --save-dev
 CMD_SLS_SERVICE_DEPLOY = $(SLS) deploy --config $(SLS_FILE) --service $(SVC) --verbose --region $(AWS_REGION) --env $(ENV) --profile $(AWS_PROFILE)
 CMD_SLS_SERVICE_INVOKE = $(SLS) invoke --function $(SVC) --path $(EVENT_FILE) --log --config $(SLS_FILE) --service $(SVC) --region $(AWS_REGION) --env $(ENV) --profile $(AWS_PROFILE)
-CMD_SLS_SERVICE_DESTROY = $(SLS) remove --config $(SLS_FILE) --service $(SVC) --verbose --region $(AWS_REGION) --env $(ENV) --profile $(AWS_PROFILE)
+CMD_SLS_SERVICE_DESTROY = $(SLS) remove --config $(SLS_FILE) --service $(SVC) --verbose --region $(AWS_REGION) --env $(ENV) --profile $(AWS_PROFILE) || true
 CMD_SLS_SERVICE_BUILD = cd $(ROOT_DIR)/$(PROJECT_PATH) && make
 CMD_SLS_SERVICE_SECRETS_PUSH = $(CMD_SERVICE_SECRETS_PUSH)
 CMD_SLS_SERVICE_SECRETS_PULL = $(CMD_SERVICE_SECRETS_PULL)

--- a/serverless/variables.mk
+++ b/serverless/variables.mk
@@ -4,5 +4,8 @@
 SLS_DOCKER_IMAGE ?= amaysim/serverless
 SLS_VERSION ?= 1.82.0
 SLS_FILE ?= serverless.yml
+SLS_DEBUG ?=
+SLS_DEPRECATION_DISABLE ?=
+SLS_WARNING_DISABLE ?=
 EVENT_FILE ?= event.json
 NODE_VERSION ?= 12-alpine3.10


### PR DESCRIPTION
- Ensure aws cli container gets removed after exit
- Add SLS_DEBUG, SLS_DEPRECATION_DISABLE and SLS_WARNING_DISABLE options
- Switch serverless to use official node image and use serverless binary that is installed via npm
- Store node_modules on a volume
- Cache .npm in a root directory of a repo
- Don't fail on non-0 exit of sls destroy
- Switch back to use root user