### PR TITLE
Add ize download and install to icmk (CORE-180)

### DIFF
--- a/ize/ize.mk
+++ b/ize/ize.mk
@@ -1,9 +1,3 @@
-#### Default settings for IZE
-IZE_DIR ?= $(INFRA_DIR)/bin
-TMPDIR ?= "/tmp"
-IZE_RELEASE ?= "v0.0.1"
-IZE_DOWNLOAD_URL = "https://hazelops-ize-bin.s3.amazonaws.com/hazelops/ize/releases/download/$(IZE_RELEASE)/$(OS_NAME).zip"
-
 #### IZE Download script
 CMD_DOWNLOAD_IZE = curl -s $(IZE_DOWNLOAD_URL) -o "$(TMPDIR)/$(OS_NAME).zip" && unzip -qq -o "$(TMPDIR)/$(OS_NAME).zip" -d "$(IZE_DIR)" && rm "$(TMPDIR)/$(OS_NAME).zip"
 
@@ -14,5 +8,5 @@ CMD_INSTALL_IZE =  chmod +x $(IZE_DIR)/ize
 ########################################################################################################################
 ize.install:
 	@$(CMD_DOWNLOAD_IZE) && \
-	$(CMD_INSTALL_IZE)
+	$(CMD_INSTALL_IZE) && \
 	@echo "\n\033[32m[OK]\033[0m IZE successfully installed"

--- a/ize/variables.mk
+++ b/ize/variables.mk
@@ -1,0 +1,7 @@
+# This file should contain variables used in current module
+##################################################################
+#### Default settings for IZE
+IZE_DIR ?= $(INFRA_DIR)/bin
+TMPDIR ?= "/tmp"
+IZE_VERSION ?= "v0.0.1"
+IZE_DOWNLOAD_URL = "https://hazelops-ize-bin.s3.amazonaws.com/hazelops/ize/releases/download/$(IZE_VERSION)/$(OS_NAME).zip"


### PR DESCRIPTION
#### What's new:

 - Added ize download and installation to MacOS and Linux


#### Testing done:
[![asciicast](https://asciinema.org/a/x3hGEVd4MZJ0DjKIbyE0wJRhu.svg)](https://asciinema.org/a/x3hGEVd4MZJ0DjKIbyE0wJRhu)
