### PR TITLE
(Core-160) version deleted from aws provider

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
-[submodule "tests/test/libs/bats-assert"]
-	path = tests/test/libs/bats-assert
-	url = https://github.com/ztombol/bats-assert
-[submodule "tests/test/libs/bats-support"]
-	path = tests/test/libs/bats-support
-	url = https://github.com/ztombol/bats-support
-[submodule "tests/test/libs/bats"]
-	path = tests/test/libs/bats
-	url = https://github.com/bats-core/bats-core
+#[submodule "tests/test/libs/bats-assert"]
+#	path = tests/test/libs/bats-assert
+#	url = https://github.com/ztombol/bats-assert
+#[submodule "tests/test/libs/bats-support"]
+#	path = tests/test/libs/bats-support
+#	url = https://github.com/ztombol/bats-support
+#[submodule "tests/test/libs/bats"]
+#	path = tests/test/libs/bats
+#	url = https://github.com/bats-core/bats-core

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
-#[submodule "tests/test/libs/bats-assert"]
-#	path = tests/test/libs/bats-assert
-#	url = https://github.com/ztombol/bats-assert
-#[submodule "tests/test/libs/bats-support"]
-#	path = tests/test/libs/bats-support
-#	url = https://github.com/ztombol/bats-support
-#[submodule "tests/test/libs/bats"]
-#	path = tests/test/libs/bats
-#	url = https://github.com/bats-core/bats-core
+[submodule "tests/test/libs/bats-assert"]
+	path = tests/test/libs/bats-assert
+	url = https://github.com/ztombol/bats-assert
+[submodule "tests/test/libs/bats-support"]
+	path = tests/test/libs/bats-support
+	url = https://github.com/ztombol/bats-support
+[submodule "tests/test/libs/bats"]
+	path = tests/test/libs/bats
+	url = https://github.com/bats-core/bats-core

--- a/terraform/templates/backend.tf.gotmpl
+++ b/terraform/templates/backend.tf.gotmpl
@@ -42,7 +42,6 @@ provider "aws" {
 provider "aws" {
   profile = var.aws_profile
   region  = var.aws_region
-  version = "{{ .Env.TERRAFORM_AWS_PROVIDER_VERSION }}"
 }
 
 terraform {


### PR DESCRIPTION
It's required for TF v1.0 upgrade

So `versions.tf` file should be updated with:
```
terraform {
  required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = "~> 3.0"
    }
```