### PR TITLE
Remove -force option from terraform destroy (CORE-220)

### DIFF
--- a/terraform/main.mk
+++ b/terraform/main.mk
@@ -116,7 +116,7 @@ terraform.destroy: ## Destroy infrastructure
 
 terraform.destroy-quiet: ## Destroy infrastructure without confirmation
 	@ cd $(ENV_DIR) && \
-	$(TERRAFORM) destroy -auto-approve -force || $(TERRAFORM) destroy -auto-approve -force
+	$(TERRAFORM) destroy -auto-approve || $(TERRAFORM) destroy -auto-approve
 	@ echo "\n\033[36m[INFO] Please run: make secrets.delete or app.delete_secrets now\033[0m"
 
 terraform.output-to-ssm: ## Manual upload output.json to AWS SSM. Output.json encoded in base64.


### PR DESCRIPTION
#### What's new:

 - Removed -force option from `make terraform destroy` and `make terraform destroy-quiet` commands for better terraform 1.x compability.